### PR TITLE
Added special handling in CompactEventCards for events with SIPB as the organizer.

### DIFF
--- a/app/util.ts
+++ b/app/util.ts
@@ -5,3 +5,7 @@ export const getLocationLink = (content: string) => {
     const isLocation = isMITLocationTest.test(content)
     return isLocation ? `https://whereis.mit.edu/?go=${content}` : ""
 }
+
+export const compareIgnoreCase = (str1: string, str2: string) => {
+    return str1.toUpperCase() == str2.toUpperCase();
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "postcss": "8.4.23",
     "rc-picker": "^3.12.0",
     "react": "18.2.0",
+    "react-confetti": "^6.1.0",
     "react-dom": "18.2.0",
     "react-redux": "^8.1.0",
     "react-shadow": "^20.0.0",


### PR DESCRIPTION
#5: Added handling so that when a CompactEventCard is displaying an event organized by SIPB (as specified by the "organizer" property) confetti and SIPB's fuzzball is shown! 
![image](https://github.com/user-attachments/assets/3533f622-9b30-4ca6-aa54-fa5cf2bd8c45)